### PR TITLE
Add new database (products-service) in test environment

### DIFF
--- a/databases-test.tf
+++ b/databases-test.tf
@@ -11,7 +11,7 @@ module "spring_boot_template_test" {
   providers = {
     postgresql = postgresql.test
   }
-} 
+}
 
 module "products_service_test" {
   source = "./modules/database"

--- a/databases-test.tf
+++ b/databases-test.tf
@@ -11,4 +11,18 @@ module "spring_boot_template_test" {
   providers = {
     postgresql = postgresql.test
   }
+} 
+
+module "products_service_test" {
+  source = "./modules/database"
+
+  database_name = "products-service-test"
+  username      = "products-service-test-user"
+  password      = "products-service-test-password"
+
+  depends_on = [time_sleep.wait_for_db]
+
+  providers = {
+    postgresql = postgresql.test
+  }
 }


### PR DESCRIPTION
This pull request adds a new module definition to the `databases-test.tf` file for setting up a test database for the `products-service`. 

Database configuration changes:

* Added `module "products_service_test"` to define a test database for the `products-service`. The module specifies the database name, username, password, dependencies, and provider configuration.